### PR TITLE
Add Keyboard and Monitor Sharing apps

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -220,6 +220,12 @@
         Color management and HDR:
         <a href="https://gitlab.freedesktop.org/wayland/wayland-protocols/-/merge_requests/14">Protocol in development</a>
       </li>
+      <li class="list__item--ko">
+        Keyboard and Mouse Sharing:
+        <a href="https://github.com/symless/synergy-core">Synergy Core</a> [<a href="https://github.com/symless/synergy-core/issues/4090">GitHub Issue</a>],
+        <a href="https://github.com/debauchee/barrier">Barrier</a> (fork of Synergy Core) [<a href="https://github.com/debauchee/barrier/issues/109">GitHub Issue</a>],
+        <a href="https://github.com/input-leap/input-leap">Input Leap</a> (fork of Barrier) [<a href="https://github.com/input-leap/input-leap/issues/109">GitHub Issue</a>]
+      </li>
     </ul>
   </section>
 


### PR DESCRIPTION
Add Keyboard and Monitor Sharing apps: Synergy Core, Barrier, Input Leap

## Description

Short description of the changes:

## Checklist

I have:

- [x] 🤳 made sure that what I am adding is an app for end users, not a developer tool / library (no "wl-clipboard-rs")
- [x] 🔗 checked that the link I am using refers to the root of the project (example, https://mpv.io) or GitHub repo **if the first is not available**
- [x] 🤓 checked BOTH the name and the casing of the project(s) I am adding ("GNOME Terminal" and not "gnome-terminal", "bemenu" and not "Bemenu", etc.)
- [x] 💣 checked that I am using spaces for indentation and that my levels are correct (**no tabs!**)
- [x] ✋ checked that my section has the correct casing ("My section", and not "My Section")
- [x] 📝 checked that the projects and / or the section are alphabetically sorted ("Clipboard manager" then "Color picker", "bemenu" then "Fuzzel")
